### PR TITLE
fix: errors when source doesn't have the _tags property

### DIFF
--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -77,7 +77,7 @@ function fixData (data) {
     data.baseUrl = removeLast(data.sourceUrl, '/') + '/'
   }
   if (!data.hasOwnProperty('_feeds')) data._feeds = {}
-  if (!data.hasOwnProperty('_tags')) data._tags = {}
+  if (!data.hasOwnProperty('_tags')) data._tags = []
   for (const [key, value] of Object.entries(data)) {
     if (key.toLowerCase().includes('url')) {
       if (Array.isArray(value)) continue
@@ -104,7 +104,7 @@ function getFavicon (url, size = 128) {
 }
 function itemShouldBeFilteredAccordingTo (item, key) {
   const result =
-    item.hasOwnProperty('_tags') &&
+    Array.isArray(item._tags) &&
     !isQueryParamSet(key) &&
     item._tags.includes(key)
   if (result) console.warn(`Item ${item.name} filtered by ${key}`)

--- a/sources.json
+++ b/sources.json
@@ -500,6 +500,10 @@
         }
     },
     {
+        "_tags": [
+            "official",
+            "working"
+        ],
         "name": "Curiosity Stream (Alpha)",
         "platformUrl": "https://curiositystream.com",
         "description": "Curiosity Stream has thousands of documentaries that enlighten, entertain & inspire. What are you curious about?",


### PR DESCRIPTION
When the source does not have the _tags property, it  was being initialized as an object instead of an array.